### PR TITLE
[Chapter 2] 예외 처리 전략

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.sparta.paymentsystem.domain.auth.dto.AuthResponse;
 import com.sparta.paymentsystem.domain.auth.dto.LoginRequest;
 import com.sparta.paymentsystem.domain.auth.dto.SignupRequest;
 import com.sparta.paymentsystem.domain.auth.service.AuthService;
+import com.sparta.paymentsystem.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,13 +19,15 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest request) {
+    public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupRequest request) {
         authService.signup(request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok());
     }
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok(authService.login(request));
+    public ResponseEntity<ApiResponse<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(
+                ApiResponse.ok(authService.login(request))
+        );
     }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.sparta.paymentsystem.domain.auth.service;
 
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import com.sparta.paymentsystem.global.jwt.JwtProvider;
 import com.sparta.paymentsystem.domain.member.entity.Member;
 import com.sparta.paymentsystem.domain.auth.dto.AuthResponse;
@@ -23,7 +25,7 @@ public class AuthService {
     @Transactional
     public void signup(SignupRequest request) {
         if (memberRepository.existsByEmail(request.email())) {
-            throw new RuntimeException("이미 존재하는 이메일입니다.");
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
         Member member = new Member(
                 request.name(),
@@ -36,10 +38,10 @@ public class AuthService {
 
     public AuthResponse login(LoginRequest request) {
         Member member = memberRepository.findByEmail(request.email())
-                .orElseThrow(() -> new RuntimeException("이메일 또는 비밀번호가 올바르지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
 
         if (!passwordEncoder.matches(request.password(), member.getPasswordHash())) {
-            throw new RuntimeException("이메일 또는 비밀번호가 올바르지 않습니다.");
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
         }
         String token = jwtProvider.createToken(member.getId(), member.getEmail());
         return new AuthResponse(token, toMemberInfo(member));

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/controller/CartController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/controller/CartController.java
@@ -6,6 +6,7 @@ import com.sparta.paymentsystem.domain.cart.dto.CartItemResponse;
 import com.sparta.paymentsystem.domain.cart.dto.UpdateCartRequest;
 import com.sparta.paymentsystem.domain.cart.facade.CartFacade;
 import com.sparta.paymentsystem.domain.cart.service.CartService;
+import com.sparta.paymentsystem.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,29 +24,29 @@ public class CartController {
     private final CartService cartService;
 
     @GetMapping("/items")
-    public ResponseEntity<List<CartItemResponse>> getItems(@AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(cartService.getCartItems(memberId));
+    public ResponseEntity<ApiResponse<List<CartItemResponse>>> getItems(@AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(ApiResponse.ok(cartService.getCartItems(memberId)));
     }
 
     @PostMapping("/items")
-    public ResponseEntity<AddCartResponse> addItem(@AuthenticationPrincipal Long memberId,
-                                                   @Valid @RequestBody AddCartRequest request) {
+    public ResponseEntity<ApiResponse<AddCartResponse>> addItem(@AuthenticationPrincipal Long memberId,
+                                                                @Valid @RequestBody AddCartRequest request) {
         Long cartItemId = cartFacade.addItem(memberId, request);
-        return ResponseEntity.ok(new AddCartResponse(cartItemId));
+        return ResponseEntity.ok(ApiResponse.ok(new AddCartResponse(cartItemId)));
     }
 
     @PatchMapping("/items/{id}")
-    public ResponseEntity<Void> updateQuantity(@AuthenticationPrincipal Long memberId,
-                                               @PathVariable Long id,
-                                               @Valid @RequestBody UpdateCartRequest request) {
+    public ResponseEntity<ApiResponse<Void>> updateQuantity(@AuthenticationPrincipal Long memberId,
+                                                            @PathVariable Long id,
+                                                            @Valid @RequestBody UpdateCartRequest request) {
         cartService.updateQuantity(memberId, id, request.quantity());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.ok());
     }
 
     @DeleteMapping("/items/{itemId}")
-    public ResponseEntity<Void> removeItem(@AuthenticationPrincipal Long memberId,
-                                           @PathVariable Long itemId) {
+    public ResponseEntity<ApiResponse<Void>> removeItem(@AuthenticationPrincipal Long memberId,
+                                                        @PathVariable Long itemId) {
         cartService.removeItem(memberId, itemId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.ok());
     }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/entity/CartItem.java
@@ -3,6 +3,8 @@ package com.sparta.paymentsystem.domain.cart.entity;
 import com.sparta.paymentsystem.domain.member.entity.Member;
 import com.sparta.paymentsystem.domain.product.entity.Product;
 import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,9 +36,7 @@ public class CartItem extends BaseTimeEntity {
     public CartItem(Member member, Product product, int quantity) {
         this.member = member;
         this.product = product;
-        if (quantity < 1) {
-            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
-        }
+        validateQuantity(quantity);
         this.quantity = quantity;
     }
 
@@ -49,16 +49,18 @@ public class CartItem extends BaseTimeEntity {
     }
 
     public void addQuantity(int quantity) {
-        if (quantity < 1) {
-            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
-        }
+        validateQuantity(quantity);
         this.quantity += quantity;
     }
 
     public void changeQuantity(int quantity) {
-        if (quantity < 1) {
-            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
-        }
+        validateQuantity(quantity);
         this.quantity = quantity;
+    }
+
+    private void validateQuantity(int quantity) {
+        if (quantity < 1) {
+            throw new BusinessException(ErrorCode.INVALID_QUANTITY);
+        }
     }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/service/CartService.java
@@ -1,8 +1,10 @@
 package com.sparta.paymentsystem.domain.cart.service;
 
-import com.sparta.paymentsystem.domain.cart.entity.CartItem;
 import com.sparta.paymentsystem.domain.cart.dto.CartItemResponse;
+import com.sparta.paymentsystem.domain.cart.entity.CartItem;
 import com.sparta.paymentsystem.domain.cart.repository.CartItemRepository;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,7 +43,7 @@ public class CartService {
     public void updateQuantity(Long memberId, Long itemId, int quantity) {
         CartItem item = cartItemRepository.findById(itemId)
                 .filter(ci -> ci.getMemberId().equals(memberId))
-                .orElseThrow(() -> new RuntimeException("장바구니 항목을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
         item.changeQuantity(quantity);
     }
 
@@ -49,7 +51,7 @@ public class CartService {
     public void removeItem(Long memberId, Long itemId) {
         int deleted = cartItemRepository.deleteByIdAndMember_Id(itemId, memberId);
         if (deleted == 0) {
-            throw new RuntimeException("장바구니 항목을 찾을 수 없습니다.");
+            throw new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/sparta/paymentsystem/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package com.sparta.paymentsystem.domain.member.controller;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.sparta.paymentsystem.domain.member.dto.MemberResponse;
 import com.sparta.paymentsystem.domain.member.service.MemberService;
+import com.sparta.paymentsystem.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/members")
@@ -15,7 +18,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> me(@AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(memberService.getMe(memberId));
+    public ResponseEntity<ApiResponse<MemberResponse>> me(@AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(ApiResponse.ok(memberService.getMe(memberId)));
     }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/member/service/MemberService.java
@@ -1,8 +1,10 @@
 package com.sparta.paymentsystem.domain.member.service;
 
-import com.sparta.paymentsystem.domain.member.entity.Member;
 import com.sparta.paymentsystem.domain.member.dto.MemberResponse;
+import com.sparta.paymentsystem.domain.member.entity.Member;
 import com.sparta.paymentsystem.domain.member.repository.MemberRepository;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +29,6 @@ public class MemberService {
 
     public Member findById(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/product/controller/ProductController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/product/controller/ProductController.java
@@ -2,9 +2,13 @@ package com.sparta.paymentsystem.domain.product.controller;
 
 import com.sparta.paymentsystem.domain.product.dto.ProductResponse;
 import com.sparta.paymentsystem.domain.product.service.ProductService;
+import com.sparta.paymentsystem.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -16,12 +20,12 @@ public class ProductController {
     private final ProductService productService;
 
     @GetMapping
-    public ResponseEntity<List<ProductResponse>> list() {
-        return ResponseEntity.ok(productService.findAll());
+    public ResponseEntity<ApiResponse<List<ProductResponse>>> list() {
+        return ResponseEntity.ok(ApiResponse.ok(productService.findAll()));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ProductResponse> detail(@PathVariable Long id) {
-        return ResponseEntity.ok(productService.findById(id));
+    public ResponseEntity<ApiResponse<ProductResponse>> detail(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(productService.findById(id)));
     }
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/product/entity/Product.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/product/entity/Product.java
@@ -1,6 +1,8 @@
 package com.sparta.paymentsystem.domain.product.entity;
 
 import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,10 +32,10 @@ public class Product extends BaseTimeEntity {
 
     public Product(String name, int price, int stock, String description) {
         if (price < 0) {
-            throw new IllegalArgumentException("가격은 0 이상이어야 합니다");
+            throw new BusinessException(ErrorCode.INVALID_PRICE);
         }
         if (stock < 0) {
-            throw new IllegalArgumentException("재고는 0 이상이어야 합니다");
+            throw new BusinessException(ErrorCode.INVALID_STOCK);
         }
         this.name = name;
         this.price = price;

--- a/src/main/java/com/sparta/paymentsystem/domain/product/service/ProductService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/product/service/ProductService.java
@@ -3,6 +3,8 @@ package com.sparta.paymentsystem.domain.product.service;
 import com.sparta.paymentsystem.domain.product.dto.ProductResponse;
 import com.sparta.paymentsystem.domain.product.entity.Product;
 import com.sparta.paymentsystem.domain.product.repository.ProductRepository;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,9 +30,8 @@ public class ProductService {
     }
 
     public Product findProductEntity(Long id) {
-        return productRepository.findById(id).orElseThrow(
-                () -> new RuntimeException("상품을 찾을 수 없습니다.")
-        );
+        return productRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
     }
 
     private ProductResponse toResponse(Product product) {
@@ -42,5 +43,4 @@ public class ProductService {
                 product.getDescription()
         );
     }
-
 }

--- a/src/main/java/com/sparta/paymentsystem/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/paymentsystem/global/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.sparta.paymentsystem.global.config;
 
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import com.sparta.paymentsystem.global.filter.JwtAuthFilter;
+import com.sparta.paymentsystem.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.springframework.boot.security.autoconfigure.web.servlet.PathRequest.toStaticResources;
 
@@ -22,6 +25,7 @@ import static org.springframework.boot.security.autoconfigure.web.servlet.PathRe
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) {
@@ -35,7 +39,9 @@ public class SecurityConfig {
                         .authenticationEntryPoint((request, response, authException) -> {
                             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                             response.setContentType("application/json;charset=UTF-8");
-                            response.getWriter().write("{\"code\":\"AUTH_001\",\"message\":\"인증이 필요합니다\"}");
+                            response.getWriter().write(
+                                    objectMapper.writeValueAsString(ApiResponse.error(ErrorCode.UNAUTHORIZED)
+                            ));
                         })
                 )
                 .authorizeHttpRequests(auth -> auth

--- a/src/main/java/com/sparta/paymentsystem/global/error/BusinessException.java
+++ b/src/main/java/com/sparta/paymentsystem/global/error/BusinessException.java
@@ -1,0 +1,19 @@
+package com.sparta.paymentsystem.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/global/error/ErrorCode.java
+++ b/src/main/java/com/sparta/paymentsystem/global/error/ErrorCode.java
@@ -1,0 +1,53 @@
+package com.sparta.paymentsystem.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "입력값이 올바르지 않습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_002", "서버 내부 오류가 발생했습니다."),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "회원을 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "MEMBER_002", "이미 존재하는 이메일입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER_003", "이메일 또는 비밀번호가 올바르지 않습니다."),
+
+    // Product
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_001", "상품을 찾을 수 없습니다."),
+    INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "PRODUCT_002", "재고가 부족합니다."),
+    INVALID_PRICE(HttpStatus.BAD_REQUEST, "PRODUCT_003", "가격은 0 이상이어야 합니다."),
+    INVALID_STOCK(HttpStatus.BAD_REQUEST, "PRODUCT_004", "재고는 0 이상이어야 합니다."),
+
+    // Cart
+    CART_EMPTY(HttpStatus.BAD_REQUEST, "CART_001", "장바구니가 비어있습니다."),
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "CART_002", "장바구니 항목을 찾을 수 없습니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "CART_003", "수량은 1 이상이어야 합니다."),
+
+    // Order
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_001", "주문을 찾을 수 없습니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER_002", "유효하지 않은 주문 상태 변경입니다."),
+
+    // Payment
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_001", "결제 정보를 찾을 수 없습니다."),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_002", "결제 금액이 일치하지 않습니다."),
+    INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "PAYMENT_003", "유효하지 않은 결제 상태 변경입니다."),
+    PAYMENT_NOT_PAID(HttpStatus.BAD_REQUEST, "PAYMENT_004", "PG사 결제가 완료되지 않았습니다."),
+    ALREADY_PROCESSED_PAYMENT(HttpStatus.CONFLICT, "PAYMENT_005", "이미 처리된 결제입니다."),
+
+    // Webhook
+    INVALID_WEBHOOK_SIGNATURE(HttpStatus.UNAUTHORIZED, "WEBHOOK_001", "웹훅 서명이 유효하지 않습니다."),
+    WEBHOOK_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "WEBHOOK_002", "웹훅 이벤트를 찾을 수 없습니다."),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 토큰입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/paymentsystem/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/paymentsystem/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.sparta.paymentsystem.global.error;
+
+import com.sparta.paymentsystem.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        ErrorCode code = e.getErrorCode();
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.error(code, e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(err -> err.getField() + ": " + err.getDefaultMessage())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("입력값이 올바르지 않습니다");
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT, message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("서버 오류 발생", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(ErrorCode.INTERNAL_ERROR));
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/global/filter/JwtAuthFilter.java
+++ b/src/main/java/com/sparta/paymentsystem/global/filter/JwtAuthFilter.java
@@ -1,6 +1,8 @@
 package com.sparta.paymentsystem.global.filter;
 
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import com.sparta.paymentsystem.global.jwt.JwtProvider;
+import com.sparta.paymentsystem.global.response.ApiResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,6 +12,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,6 +22,7 @@ import java.util.List;
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -34,6 +38,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 UsernamePasswordAuthenticationToken auth =
                         new UsernamePasswordAuthenticationToken(memberId, null, List.of());
                 SecurityContextHolder.getContext().setAuthentication(auth);
+            } else {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write(
+                        objectMapper.writeValueAsString(ApiResponse.error(ErrorCode.INVALID_TOKEN))
+                );
             }
         }
 

--- a/src/main/java/com/sparta/paymentsystem/global/response/ApiResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/global/response/ApiResponse.java
@@ -1,0 +1,42 @@
+package com.sparta.paymentsystem.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sparta.paymentsystem.global.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private static final String SUCCESS_CODE = "SUCCESS";
+
+    private final String code;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(String code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(SUCCESS_CODE, null, data);
+    }
+
+    public static ApiResponse<Void> ok() {
+        return new ApiResponse<>(SUCCESS_CODE, null, null);
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(errorCode.getCode(), message, null);
+    }
+
+    public static ApiResponse<Void> error(String code, String message) {
+        return new ApiResponse<>(code, message, null);
+    }
+}

--- a/src/test/http/product.http
+++ b/src/test/http/product.http
@@ -1,0 +1,5 @@
+### TC-1. 존재하지 않는 상품 조회 → 기대: 404 Not Found + {"code":"PRODUCT_001","message":"상품을 찾을 수 없습니다."}
+GET http://localhost:8080/api/products/999
+
+### TC-2. 잘못된 요청 형식 → 기대: 400 Bad Request + 공통 에러 형식
+GET http://localhost:8080/api/products/abc


### PR DESCRIPTION
**변경 사항**

- ErrorCode enum 구현 (Common, Member, Product, Cart, Order, Payment, Webhook, Auth 도메인별 에러 코드)
- BusinessException 커스텀 예외 클래스 구현 (RuntimeException 상속, ErrorCode 포함)
- ApiResponse<T> 공통 응답 래퍼 구현 (ok/error 정적 팩토리 + @JsonInclude(NON_NULL))
- GlobalExceptionHandler 구현 (BusinessException, MethodArgumentNotValidException, Exception 처리)
- 기존 코드들에 BusinessException & ApiResponse 적용 리팩토링

**테스트**

- [x]  수동 테스트 완료 (Postman / 브라우저)
    - `GET /api/products/999` → 404 + `{ code: "PRODUCT_001", message: "상품을 찾을 수 없습니다" }`
    - `GET /api/products/abc` → 400 + 공통 에러 형식
- [x]  기존 기능 영향 없음 확인

**스크린샷**

(Postman 테스트 결과 캡처 첨부)

**관련 Issue**

- Closes #7