### PR TITLE
[Chapter 3] 주문서 페이지 구현

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/repository/CartItemRepository.java
@@ -19,4 +19,10 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     @Query("DELETE FROM CartItem ci WHERE ci.id = :id AND ci.member.id = :memberId")
     int deleteByIdAndMember_Id(@Param("id") Long id, @Param("memberId") Long memberId);
 
+    // 주문서에 담을 선택된 장바구니 아이템을 상품 정보와 함께 조회
+    // - memberId 조건 : 다른 회원의 cartItemId를 넘겨도 조회되지 않도록 고유권 검증
+    // - JOIN FETCH : 주문서에서 상품명/가격을 써야 하므로 n+1 방지
+    @Query("SELECT ci FROM CartItem ci JOIN FETCH ci.product WHERE ci.id IN :ids AND ci.member.id = :memberId")
+    List<CartItem> findByIdInAndMember_IdWithProduct(@Param("ids") List<Long> ids, @Param("memberId") Long memberId);
+
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/cart/service/CartService.java
@@ -55,6 +55,14 @@ public class CartService {
         }
     }
 
+    public List<CartItem> findCartEntities(Long memberId) {
+        return cartItemRepository.findByMemberId(memberId);
+    }
+
+    public List<CartItem> findCartEntitiesByIds(Long memberId, List<Long> cartItemIds) {
+        return cartItemRepository.findByIdInAndMember_IdWithProduct(cartItemIds, memberId);
+    }
+
     private CartItemResponse toResponse(CartItem item) {
         return new CartItemResponse(
                 item.getId(),

--- a/src/main/java/com/sparta/paymentsystem/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/controller/OrderController.java
@@ -1,0 +1,31 @@
+package com.sparta.paymentsystem.domain.order.controller;
+
+import com.sparta.paymentsystem.domain.order.dto.CheckoutResponse;
+import com.sparta.paymentsystem.domain.order.facade.OrderFacade;
+import com.sparta.paymentsystem.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderFacade orderFacade;
+
+    @GetMapping("/checkout")
+    public ResponseEntity<ApiResponse<CheckoutResponse>> checkout(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(required = false) List<Long> cartItemIds
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(orderFacade.getCheckout(memberId, cartItemIds)));
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/dto/CheckoutResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/dto/CheckoutResponse.java
@@ -1,0 +1,16 @@
+package com.sparta.paymentsystem.domain.order.dto;
+
+import java.util.List;
+
+public record CheckoutResponse(
+        List<CheckoutItemResponse> items,
+        int totalPrice
+) {
+    public record CheckoutItemResponse(
+            Long productId,
+            String productName,
+            int price,
+            int quantity,
+            int subtotal
+    ) {}
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/facade/OrderFacade.java
@@ -1,0 +1,74 @@
+package com.sparta.paymentsystem.domain.order.facade;
+
+import com.sparta.paymentsystem.domain.cart.entity.CartItem;
+import com.sparta.paymentsystem.domain.cart.facade.CartFacade;
+import com.sparta.paymentsystem.domain.cart.service.CartService;
+import com.sparta.paymentsystem.domain.order.dto.CheckoutResponse;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderFacade {
+
+    private final CartService cartService;
+
+    public CheckoutResponse getCheckout(Long memberId, List<Long> cartItemIds) {
+        // 주문서 미리보기: 재고 차감/주문 생성 없는 읽기 전용
+        // cartItemIds가 null/비어있으면 "전체 장바구니", 값이 있으면 "선택된 아이템만" 주문서에 담는다.
+        List<CartItem> cartItems = getValidateCartItems(
+                memberId, cartItemIds != null ? cartItemIds : List.of()
+        );
+
+        // 장바구니 아이템에서 상품 가격과 장바구니 수량을 곱해서 각 아이템의 총액을 구한다.
+        // CartItem을 CheckoutResponse.CheckoutItemResponse로 변환
+        List<CheckoutResponse.CheckoutItemResponse> items = cartItems.stream()
+                .map(cartItem -> {
+                    int price = cartItem.getProduct().getPrice();
+                    int subtotal = price * cartItem.getQuantity();
+                    return new CheckoutResponse.CheckoutItemResponse(
+                            cartItem.getProductId(),
+                            cartItem.getProduct().getName(),
+                            price,
+                            cartItem.getQuantity(),
+                            subtotal
+                    );
+                })
+                .toList();
+
+        // 장바구니 주문 총액을 구한다. CheckoutResponse.CheckoutItemResponse의 subtotal을 모두 더한다.
+        int totalPrice = items.stream()
+                .mapToInt(CheckoutResponse.CheckoutItemResponse::subtotal)
+                .sum();
+
+        return new CheckoutResponse(items, totalPrice);
+    }
+
+    private List<CartItem> getValidateCartItems(Long memberId, List<Long> cartItemIds) {
+        // cartItemIds가 비어있으면 "전체 장바구니", 아니면 "선택된 아이템만" 조회
+        List<CartItem> cartItems = cartItemIds.isEmpty()
+                ? cartService.findCartEntities(memberId)
+                : cartService.findCartEntitiesByIds(memberId, cartItemIds);
+
+        // 1차 검증: 주문할 아이템이 하나도 없으면 주문서 자체가 성립하지 않는다.
+        // (전체 조회: 빈 장바구니 / 선택 조회: 넘긴 ID가 전부 남의 것/없는 것일 때도 여기로 떨어짐)
+        if (cartItems.isEmpty()) {
+            throw new BusinessException(ErrorCode.CART_EMPTY);
+        }
+
+        // 2차 검증: 요청한 ID 개수와 조회된 개수가 다르다. -> 일부가 "남의 것" 또는 "존재하지 않는 ID"다.
+        // -> 일부만 주문되는 상황을 막고, 명시적으로 에러를 던진다.
+        if (!cartItemIds.isEmpty() && cartItems.size() != cartItemIds.size()) {
+            throw new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND);
+        }
+
+        return cartItems;
+    }
+
+}

--- a/src/test/http/cart.http
+++ b/src/test/http/cart.http
@@ -7,7 +7,7 @@ Content-Type: application/json
   "password": "sparta1234"
 }
 
-> {% client.global.set("authToken", response.body.token); %}
+> {% client.global.set("authToken", response.body.data.token); %}
 
 ### TC-6. 수량 변경 (잘못된 값) — 기대: 400 Bad Request
 PATCH http://localhost:8080/api/cart/items/1

--- a/src/test/http/order.http
+++ b/src/test/http/order.http
@@ -1,0 +1,14 @@
+### 로그인 (토큰 발급)
+POST http://localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "sparta@nbcamp.com",
+  "password": "sparta1234"
+}
+
+> {% client.global.set("authToken", response.body.data.token); %}
+
+### TC-2. 장바구니 비어 있을 때 주문서 조회 → 기대: 400 Bad Request + {"code":"CART_001","message":"장바구니가 비어있습니다."}
+GET http://localhost:8080/api/orders/checkout
+Authorization: Bearer {{authToken}}


### PR DESCRIPTION
**변경 사항**

- CartItemRepository에 findByIdInAndMember_IdWithProduct() 선택 조회 메서드 추가
- CartService에 findCartEntities()/findCartEntitiesByIds() 엔티티 조회 메서드 추가
- CheckoutResponse DTO 구현 (CheckoutItemResponse 내부 record 포함, subtotal/totalPrice 서버 합산)
- OrderFacade.getCheckout() 메서드 구현 (장바구니 조회 → 현재 가격 반영 → DTO 변환, 장바구니 비어있을 때 예외 처리)
- OrderController 구현 (GET /api/orders/checkout, 선택적 cartItemIds 파라미터 지원)

**테스트**

- [x]  수동 테스트 완료 (Postman / 브라우저)
    - `GET /api/orders/checkout` (정상) → 200 OK + 주문서 항목 + totalPrice
    - `GET /api/orders/checkout` (장바구니 비어있을 때) → 400 + 에러 응답
- [x]  기존 기능 영향 없음 확인

**스크린샷**

(Postman 테스트 결과 캡처 첨부)

**관련 Issue**

- Closes #9