### PR TITLE
[Chapter 3] PorOne 셋업

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/infra/portone/config/PortOneConfig.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/config/PortOneConfig.java
@@ -1,0 +1,27 @@
+package com.sparta.paymentsystem.infra.portone.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class PortOneConfig {
+
+    private final PortOneProperties properties;
+
+    @Bean
+    public RestClient portOneRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(3000);  // 3초
+        requestFactory.setReadTimeout(5000);     // 5초
+
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader("Authorization", "PortOne " + properties.getApiSecret())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/config/PortOneProperties.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/config/PortOneProperties.java
@@ -1,0 +1,16 @@
+package com.sparta.paymentsystem.infra.portone.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "portone")
+@Getter @Setter
+public class PortOneProperties {
+    private String baseUrl;
+    private String apiSecret;
+    private String storeId;
+    private String channelKey;
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/controller/PortOneConfigController.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/controller/PortOneConfigController.java
@@ -1,0 +1,24 @@
+package com.sparta.paymentsystem.infra.portone.controller;
+
+import com.sparta.paymentsystem.global.response.ApiResponse;
+import com.sparta.paymentsystem.infra.portone.config.PortOneProperties;
+import com.sparta.paymentsystem.infra.portone.dto.PortOneConfigResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PortOneConfigController {
+
+    private final PortOneProperties portOneProperties;
+
+    @GetMapping("/api/config/portone")
+    public ResponseEntity<ApiResponse<PortOneConfigResponse>> getConfig() {
+        return ResponseEntity.ok(ApiResponse.ok(new PortOneConfigResponse(
+                portOneProperties.getStoreId(),
+                portOneProperties.getChannelKey()
+        )));
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/dto/PortOneConfigResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/dto/PortOneConfigResponse.java
@@ -1,0 +1,6 @@
+package com.sparta.paymentsystem.infra.portone.dto;
+
+public record PortOneConfigResponse(
+        String storeId,
+        String channelKey
+) {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,3 +35,9 @@ server:
 jwt:
   secret: "c3BhcnRhLXBheW1lbnQtand0LXNlY3JldC1rZXktZm9yLWJvb3RjYW1wLTIwMjYtdmVyeS1sb25nLXNlY3JldA=="  # Base64 encoded
   expiration: 3600000  # 1시간 (ms)
+
+portone:
+  base-url: "https://api.portone.io"
+  api-secret: ${PORTONE_API_SECRET}
+  store-id: ${PORTONE_STORE_ID}
+  channel-key: ${PORTONE_CHANNEL_KEY}

--- a/src/test/http/portone-config.http
+++ b/src/test/http/portone-config.http
@@ -1,0 +1,19 @@
+### TC-1. PortOne 설정 조회 API
+# 기대: 200 OK + storeId, channelKey 반환
+# 검증: apiSecret이 응답에 포함되지 않음
+GET http://localhost:8080/api/config/portone
+
+> {%
+    client.test("응답 코드 200", function () {
+        client.assert(response.status === 200, "Expected 200 OK");
+    });
+    client.test("storeId 존재", function () {
+        client.assert(response.body.data.storeId != null, "storeId should not be null");
+    });
+    client.test("channelKey 존재", function () {
+        client.assert(response.body.data.channelKey != null, "channelKey should not be null");
+    });
+    client.test("apiSecret 미포함", function () {
+        client.assert(response.body.data.apiSecret === undefined, "apiSecret should not be exposed");
+    });
+%}


### PR DESCRIPTION
**변경 사항**

- PortOne 환경 셋업 완료 (KG이니시스 테스트 채널, 하위 상점 생성, API Secret 발급)
- application.yaml에 실제 PortOne 설정값 반영 (storeId, channelKey, apiSecret 환경변수 바인딩)
- PortOneProperties 설정 바인딩 클래스 생성
- PortOneConfig : RestClient Bean 등록
- PortOneConfigResponse DTO 구현 (storeId, channelKey만 공개 : apiSecret 제외)
- PortOneConfigController 구현 (GET /api/config/portone, 인증 불필요)

**테스트**

- [x]  수동 테스트 완료 (Postman / 브라우저)
    - `GET /api/config/portone` → 200 OK + `{ storeId, channelKey }` 반환
    - 응답에 `apiSecret`이 포함되지 않음 확인
- [ ]  기존 기능 영향 없음 확인

**스크린샷**

(Postman 테스트 결과 + PortOne 콘솔 캡처 첨부)

**관련 Issue**

- Closes #15