### PR TITLE
[Chapter 4] PortOne 결제 대행사 포트 구현

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/payment/port/PaymentGateway.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/port/PaymentGateway.java
@@ -1,0 +1,10 @@
+package com.sparta.paymentsystem.domain.payment.port;
+
+public interface PaymentGateway {
+
+    // PG사에서 실제 결제 정보 조회 (금액 검증용)
+    PaymentGatewayResponse getPayment(String paymentId);
+
+    // 결제 전액 취소
+    void cancelPayment(String paymentId, String reason);
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/port/PaymentGatewayResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/port/PaymentGatewayResponse.java
@@ -1,0 +1,7 @@
+package com.sparta.paymentsystem.domain.payment.port;
+
+public record PaymentGatewayResponse(
+        String id,
+        String status,
+        int totalAmount
+) {}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/client/PortOneClient.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/client/PortOneClient.java
@@ -1,0 +1,55 @@
+package com.sparta.paymentsystem.infra.portone.client;
+
+import com.sparta.paymentsystem.domain.payment.port.PaymentGateway;
+import com.sparta.paymentsystem.domain.payment.port.PaymentGatewayResponse;
+import com.sparta.paymentsystem.infra.portone.config.PortOneProperties;
+import com.sparta.paymentsystem.infra.portone.dto.PortOneCancelRequest;
+import com.sparta.paymentsystem.infra.portone.dto.PortOnePaymentResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PortOneClient implements PaymentGateway {
+
+    private final RestClient portOneRestClient;
+    private final PortOneProperties portOneProperties;
+
+    @Override
+    public PaymentGatewayResponse getPayment(String paymentId) {
+        // paymentId logging
+        log.info("PortOne 결제 조회: {}", paymentId);
+
+        // portOneRestClient https://api.portone.io/payments/{paymnetId}?storeId={storeId}
+        PortOnePaymentResponse response = portOneRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/payments/{paymentId}")
+                        .queryParam("storeId", portOneProperties.getStoreId())
+                        .build(paymentId))
+                .retrieve()
+                .body(PortOnePaymentResponse.class);
+
+        // PortOne 응답 결과인 PortOnePaymentResponse를 PaymentGatewayResponse로 변환
+        return new PaymentGatewayResponse(
+                response.id(),
+                response.status(),
+                response.amount().total()
+        );
+    }
+
+    @Override
+    public void cancelPayment(String paymentId, String reason) {
+        // paymentId logging
+        log.info("PortOne 결제 취소 요청: paymentId={}, reason={}", paymentId, reason);
+
+        // portOneRestClient https://api.portone.io/payments/{paymnetId}/cancel body: {reason, storeId}
+        portOneRestClient.post()
+                .uri("/payments/{paymentId}/cancel", paymentId)
+                .body(new PortOneCancelRequest(reason, portOneProperties.getStoreId()))
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/dto/PortOneCancelRequest.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/dto/PortOneCancelRequest.java
@@ -1,0 +1,22 @@
+package com.sparta.paymentsystem.infra.portone.dto;
+
+/**
+ * PortOne V2 결제 취소 요청 (POST /payments/{paymentId}/cancel)
+ *
+ * 이 프로젝트에서 필요한 핵심 필드만 선언했습니다.
+ *
+ * 전체 요청 필드는 PortOne V2 API 문서를 참고하세요.
+ * https://developers.portone.io/api/rest-v2/payment
+ *
+ * 주요 생략 필드:
+ * - amount: 취소 총 금액 (값을 입력하지 않으면 전액 취소됩니다.)
+ * - taxFreeAmount: 취소 금액 중 면세 금액 (값을 입력하지 않으면 전액 과세 취소됩니다.)
+ * - vatAmount: 취소 금액 중 부가세액 (값을 입력하지 않으면 자동 계산됩니다.)
+ * - requester: 결제 취소 요청 주체, CancelRequester(CUSTOMER / ADMIN)
+ * - currentCancellableAmount: 결제 건의 취소 가능 잔액 (본 취소 요청 이전의 취소 가능 잔액으로써, 값을 입력하면 잔액이 일치하는 경우에만 취소가 진행됩니다. 값을 입력하지 않으면 별도의 검증 처리를 수행하지 않습니다.)
+ * - refundAccount: 고객 정보 입력 형식 CancelPaymentBodyRefundAccount(bank, number, holderName)
+ */
+public record PortOneCancelRequest(
+        String reason,   // [필수] 취소 사유
+        String storeId   // [조건부] 하위 상점 사용 시 필수
+) {}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/dto/PortOnePaymentResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/dto/PortOnePaymentResponse.java
@@ -1,0 +1,51 @@
+package com.sparta.paymentsystem.infra.portone.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * PortOne V2 결제 조회 응답 (GET /payments/{paymentId})
+ *
+ * 이 프로젝트에서 필요한 핵심 필드만 선언했습니다.
+ *
+ * Jackson의 @JsonIgnoreProperties(ignoreUnknown = true)로
+ * 여기에 없는 필드는 자동 무시됩니다.
+ *
+ * 전체 응답 필드는 PortOne V2 API 문서를 참고하세요.
+ * https://developers.portone.io/api/rest-v2/payment
+ *
+ * 주요 생략 필드:
+ * - transactionId: PortOne 거래 고유 채번 ID
+ * - method: 결제수단 정보 (PaymentMethod)
+ * - merchantId: 고객사 ID
+ * - customer: 구매자 정보 (Customer)
+ * - channel: 선택된 채널 정보
+ * - scheduleId: 결제 예약 건 아이디 (결제 예약을 이용한 경우에만 존재)
+ * - billingKey: 결제 시 사용된 빌링키 (빌링키 결제인 경우에만 존재)
+ * - webhooks: 웹훅 발송 내역 (Array<PaymentWebhook>)
+ * - promotionId: 프로모션 ID
+ * - requestedAt, updatedAt, statusChangedAt : 각 시점 타임스탬프
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PortOnePaymentResponse(
+        String id,                            // 결제 건 ID (우리가 생성한 paymentId)
+        String status,                        // 결제 상태: READY, PAID, FAILED, CANCELLED, PARTIAL_CANCELLED
+        PaymentAmount amount                  // 결제 금액 세부 정보
+) {
+
+    /**
+     * 결제 금액 세부 정보
+     *
+     * 주요 생략 필드:
+     * - taxFree: 면세액
+     * - vat: 부가세액
+     * - supply: 공급가액
+     * - discount: 총 할인금액
+     * - paid: 실제 결제금액
+     * - cancelled: 총 취소금액
+     * - cancelledTaxFree: 총 취소금액 중 면세액
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record PaymentAmount(
+            int total     // 총 결제 금액
+    ) {}
+}

--- a/src/test/java/com/sparta/paymentsystem/infra/portone/client/PortOneClientTest.java
+++ b/src/test/java/com/sparta/paymentsystem/infra/portone/client/PortOneClientTest.java
@@ -1,0 +1,46 @@
+package com.sparta.paymentsystem.infra.portone.client;
+
+import com.sparta.paymentsystem.domain.payment.port.PaymentGateway;
+import com.sparta.paymentsystem.domain.payment.port.PaymentGatewayResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@SpringBootTest
+class PortOneClientTest {
+
+    @Autowired
+    private PaymentGateway paymentGateway;
+
+    private static final String PAYMENT_ID = "TC-1에서_복사한_paymentId";
+
+    @Test
+    @DisplayName("TC-2. PortOne 결제 조회 — TC-1 결제 후 paymentId로 검증")
+    void getPayment_TC1_paymentId() {
+        PaymentGatewayResponse response = paymentGateway.getPayment(PAYMENT_ID);
+
+        System.out.println("status     : " + response.status());
+        System.out.println("totalAmount: " + response.totalAmount());
+
+        assertThat(response.id()).isEqualTo(PAYMENT_ID);
+        assertThat(response.status()).isEqualTo("PAID");
+        assertThat(response.totalAmount()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("TC-3. PortOne 결제 취소 — TC-2 조회 확인 후 실행")
+    void cancelPayment_TC1_paymentId() {
+        // 취소 실행 (예외 없이 완료되면 성공)
+        assertThatNoException().isThrownBy(() ->
+                paymentGateway.cancelPayment(PAYMENT_ID, "테스트 취소")
+        );
+
+        // 취소 후 상태 재조회
+        PaymentGatewayResponse response = paymentGateway.getPayment(PAYMENT_ID);
+        assertThat(response.status()).isEqualTo("CANCELLED");
+    }
+}


### PR DESCRIPTION
**변경 사항**

- PaymentGatewayResponse DTO 정의 (id/status/totalAmount)
- PaymentGateway 포트 인터페이스 정의 (getPayment/cancelPayment)
- PortOnePaymentResponse, PortOneCancelRequest DTO 구현
- PaymentGateway 인터페이스의 구현체인 PortOneClient 구현 (getPayment(), cancelPayment())

**테스트**

- [x]  수동 테스트 완료 (Postman / 브라우저)
    - 장바구니 → 주문서 → "결제하기" 클릭 → PortOne 결제창 팝업 확인
    - 결제 성공 확인
    - 포트 인터페이스 통한 결제 조회/취소 확인
- [x]  기존 기능 영향 없음 확인

**스크린샷**

(결제창 팝업 캡처 + 테스트 결과 첨부)

**관련 Issue**

- Closes #17