### PR TITLE
[Chapter 4] 결제 승인 구현

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/entity/Order.java
@@ -2,6 +2,8 @@ package com.sparta.paymentsystem.domain.order.entity;
 
 import com.sparta.paymentsystem.domain.member.entity.Member;
 import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -54,6 +56,22 @@ public class Order extends BaseTimeEntity {
         String firstName = orderItems.get(0).getProductName();
         if (orderItems.size() == 1) return firstName;
         return firstName + " 외 " + (orderItems.size() - 1) + "건";
+    }
+
+    public void markAsConfirmed() {
+        changeStatus(OrderStatus.CONFIRMED);
+    }
+
+    public void markAsCancelled() {
+        changeStatus(OrderStatus.CANCELLED);
+    }
+
+    // 주문 상태 변경 로직
+    private void changeStatus(OrderStatus newStatus) {
+        if (!this.status.canTransitTo(newStatus)) {
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+        this.status = newStatus;
     }
 
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/entity/OrderItem.java
@@ -49,4 +49,8 @@ public class OrderItem extends BaseTimeEntity {
         return orderPrice * quantity;
     }
 
+    public Long getProductId() {
+        return this.product.getId();
+    }
+
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/order/service/OrderService.java
@@ -55,4 +55,16 @@ public class OrderService {
         );
     }
 
+    // 주문 상태 변경 (CONFIRMED)
+    @Transactional
+    public void confirmOrder(Order order) {
+        order.markAsConfirmed();
+    }
+
+    // 주문 상태 변경 (CANCELLED)
+    @Transactional
+    public void cancelOrder(Order order) {
+        order.markAsCancelled();
+    }
+
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/controller/PaymentController.java
@@ -1,0 +1,29 @@
+package com.sparta.paymentsystem.domain.payment.controller;
+
+import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmRequest;
+import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmResponse;
+import com.sparta.paymentsystem.domain.payment.facade.PaymentFacade;
+import com.sparta.paymentsystem.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentFacade paymentFacade;
+
+    @PostMapping("/confirm")
+    public ResponseEntity<ApiResponse<PaymentConfirmResponse>> confirmPayment(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody PaymentConfirmRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(paymentFacade.confirmPayment(memberId, request)));
+    }
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/dto/PaymentConfirmRequest.java
@@ -1,0 +1,12 @@
+package com.sparta.paymentsystem.domain.payment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PaymentConfirmRequest(
+        @NotNull(message = "주문 ID는 필수입니다")
+        Long orderId,
+
+        @NotBlank(message = "PortOne 결제 ID는 필수입니다")
+        String portonePaymentId
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/dto/PaymentConfirmResponse.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/dto/PaymentConfirmResponse.java
@@ -1,0 +1,10 @@
+package com.sparta.paymentsystem.domain.payment.dto;
+
+public record PaymentConfirmResponse(
+        Long paymentId,
+        Long orderId,
+        int amount,
+        String paymentStatus,
+        String orderStatus,
+        String message
+) {}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/entity/Payment.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/entity/Payment.java
@@ -2,6 +2,8 @@ package com.sparta.paymentsystem.domain.payment.entity;
 
 import com.sparta.paymentsystem.domain.order.entity.Order;
 import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -45,6 +47,23 @@ public class Payment extends BaseTimeEntity {
 
     private static String generatePortonePaymentId() {
         return "pay_" + UUID.randomUUID();
+    }
+
+    public void markAsPaid() {
+        changeStatus(PaymentStatus.PAID);
+        this.paidAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed() {
+        changeStatus(PaymentStatus.FAILED);
+    }
+
+    // 결제 상태 변경 로직
+    private void changeStatus(PaymentStatus newStatus) {
+        if (!this.status.canTransitTo(newStatus)) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_STATUS);
+        }
+        this.status = newStatus;
     }
 
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/facade/PaymentFacade.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/facade/PaymentFacade.java
@@ -1,0 +1,118 @@
+package com.sparta.paymentsystem.domain.payment.facade;
+
+import com.sparta.paymentsystem.domain.order.entity.Order;
+import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmRequest;
+import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmResponse;
+import com.sparta.paymentsystem.domain.payment.entity.Payment;
+import com.sparta.paymentsystem.domain.payment.entity.PaymentStatus;
+import com.sparta.paymentsystem.domain.payment.port.PaymentGateway;
+import com.sparta.paymentsystem.domain.payment.port.PaymentGatewayResponse;
+import com.sparta.paymentsystem.domain.payment.service.PaymentCommandService;
+import com.sparta.paymentsystem.domain.payment.service.PaymentService;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 결제 승인 유스케이스 Facade
+ *
+ * "결제 승인"은 단순히 DB 상태만 바꾸는 게 아니다.
+ *   - 우리 DB의 결제/주문 상태
+ *   - PG사(PortOne)의 실제 결제 상태/금액
+ * 두 세계를 맞춰 보고, 조작/오류가 감지되면 즉시 취소까지 해야 하는 보안 로직이다.
+ *
+ * 이 클래스는 "외부 API 호출(트랜잭션 밖)"과 "DB 상태 변경(트랜잭션 안)"을 섞지 않기 위해
+ * 트랜잭션을 걸지 않고, DB 변경은 PaymentCommandService 로 위임한다.
+ *
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentFacade {
+
+    // PortOne 결제 완료 상태값. 문자열 비교 시 매직 스트링을 피하기 위해 상수화.
+    private static final String PG_STATUS_PAID = "PAID";
+
+    private final PaymentService paymentService;
+    private final PaymentCommandService paymentCommandService;
+    private final PaymentGateway paymentGateway;
+
+    /**
+     * 결제 승인 메인 흐름
+     *
+     * 1. 주문/결제 조회 + 소유자/상태/portonePaymentId 검증
+     * 2. [외부 API] PG사에서 실제 결제 정보 조회
+     * 3. PortOne 상태 검증 : PAID 가 아니면 결제/주문 실패 처리
+     * 4. 금액 검증 : DB 금액과 PG 금액 불일치 시 PG 자동 취소 + 결제/주문 실패 처리
+     * 5. [트랜잭션] 모두 통과하면 DB 상태를 PAID/CONFIRMED 로 변경
+     *
+     * 주의: 이 메서드 자체에는 @Transactional 이 없다.
+     * 외부 API 호출을 트랜잭션 안에서 하면 커넥션을 오래 점유하고, 롤백 시에도 PG 상태를 되돌릴 수 없기 때문
+     */
+    public PaymentConfirmResponse confirmPayment(Long memberId, PaymentConfirmRequest request) {
+        // 1. 결제 조회 + 소유자 검증
+        //    다른 사람의 주문을 승인하지 못하게 memberId 를 함께 확인한다.
+        Payment payment = paymentService.findByOrderIdWithOrder(request.orderId());
+        Order order = payment.getOrder();
+        if (!order.getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
+        }
+
+        // 1-1. 이미 처리된 결제인지 선검증
+        //      IN_PROGRESS 가 아니면 이미 승인/취소/실패된 건이므로 PG 호출 자체를 하지 않는다.
+        //      (중복 클릭/재요청으로 인한 불필요한 외부 API 호출 방지)
+        if (payment.getStatus() != PaymentStatus.IN_PROGRESS) {
+            throw new BusinessException(ErrorCode.ALREADY_PROCESSED_PAYMENT);
+        }
+
+        // 1-2. 클라이언트가 보낸 portonePaymentId 와 DB 값 일치 검증
+        //      악의적인 사용자가 남의 결제 id 로 승인 요청을 보내는 것을 막는다.
+        String portonePaymentId = payment.getPortonePaymentId();
+        if (!portonePaymentId.equals(request.portonePaymentId())) {
+            log.warn("결제 승인 거부 — portonePaymentId 불일치: DB={}, 요청={}",
+                    portonePaymentId, request.portonePaymentId());
+            throw new BusinessException(ErrorCode.PAYMENT_NOT_FOUND);
+        }
+
+        // 2. 외부 API: PG사에서 실제 결제 정보 조회
+        //    "우리 DB 가 말하는 결제"가 아니라 "PG 가 말하는 결제"를 신뢰한다.
+        PaymentGatewayResponse pgPayment = paymentGateway.getPayment(portonePaymentId);
+
+        // 3. PortOne 상태 검증
+        //    PG가 PAID 라고 응답하지 않으면 결제가 정상 완료된 것이 아니다.
+        //    → 우리 DB 의 결제/주문을 실패 처리하고, 재고도 복구해 둔다.
+        if (!PG_STATUS_PAID.equals(pgPayment.status())) {
+            log.error("결제 승인 실패 — PG 상태 비정상: paymentId={}, pgStatus={}",
+                    payment.getId(), pgPayment.status());
+            paymentCommandService.failPaymentAndOrder(order.getId());
+            throw new BusinessException(ErrorCode.PAYMENT_NOT_PAID);
+        }
+
+        // 4. 금액 검증 ("금액 조작 문제" 해결)
+        //    프론트에서 가격을 조작해 결제창을 띄웠을 수 있으므로
+        //    DB 에 기록된 "서버가 계산한 금액"과 PG 가 실제 받은 금액을 대조한다.
+        //    불일치 시:
+        //      1) PG 측 결제를 즉시 취소 (돈을 돌려줘야 함)
+        //      2) 우리 DB 결제/주문도 실패 처리
+        //    PG 취소 호출이 실패해도 로그만 남기고 흐름을 이어간다.
+        //    돈이 이미 나갔을 수 있으므로 운영자 수동 대응이 필요
+        if (payment.getAmount() != pgPayment.totalAmount()) {
+            log.error("결제 승인 실패 — 금액 불일치 (조작 가능성): paymentId={}, DB금액={}, PG금액={}",
+                    payment.getId(), payment.getAmount(), pgPayment.totalAmount());
+            try {
+                paymentGateway.cancelPayment(portonePaymentId, "결제 금액 불일치 자동 취소");
+            } catch (Exception e) {
+                log.error("PG 자동 취소 실패 : 수동 처리 필요: portonePaymentId={}", portonePaymentId, e);
+            }
+            paymentCommandService.failPaymentAndOrder(order.getId());
+            throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+
+        // 5. 모든 검증 통과 → DB 상태를 최종 승인으로 전환
+        //    실제 상태 변경은 트랜잭션이 걸린 CommandService 에서 수행한다.
+        return paymentCommandService.approvePaymentAndOrder(order.getId());
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/repository/PaymentRepository.java
@@ -22,4 +22,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     // 타입 안정은 떨어지므로, 실무에선 인터페이스/레코드 프로젝션으로 개선 가능
     @Query("SELECT p.order.id, p.id FROM Payment p WHERE p.order.id IN :orderIds")
     List<Object[]> findIdsByOrderIds(@Param("orderIds") List<Long> orderIds);
+
+    // 주문 단건 상세 조회 : orderId만으로 조회
+    @Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.order.id = :orderId")
+    Optional<Payment> findByOrderIdWithOrder(@Param("orderId") Long orderId);
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentCommandService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentCommandService.java
@@ -1,0 +1,99 @@
+package com.sparta.paymentsystem.domain.payment.service;
+
+import com.sparta.paymentsystem.domain.order.entity.Order;
+import com.sparta.paymentsystem.domain.order.entity.OrderItem;
+
+import com.sparta.paymentsystem.domain.order.service.OrderService;
+import com.sparta.paymentsystem.domain.payment.dto.PaymentConfirmResponse;
+import com.sparta.paymentsystem.domain.payment.entity.Payment;
+import com.sparta.paymentsystem.domain.product.entity.Product;
+import com.sparta.paymentsystem.domain.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 결제 승인/실패 시 여러 도메인(결제, 주문, 상품)을 한 트랜잭션으로 묶어 처리하는 서비스
+ *
+ * - PaymentService: 결제 상태 변경
+ * - OrderService: 주문 상태 변경
+ * - ProductService: 재고 복구
+ *
+ * 개별 서비스는 자기 도메인만 책임지고, 여러 도메인에 걸친 "유스케이스"는 이 클래스가 조립한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class PaymentCommandService {
+
+    private final PaymentService paymentService;
+    private final OrderService orderService;
+    private final ProductService productService;
+
+    /**
+     * 결제 실패 처리
+     *
+     * 흐름:
+     *   1) 주문 ID로 결제 + 주문을 함께 조회 (fetch join)
+     *   2) 결제 상태 → FAILED
+     *   3) 주문 상태 → CANCELED
+     *   4) 주문에 포함된 상품들의 재고를 원래대로 복구
+     *
+     * 주문 생성 시 차감했던 재고를 되돌려 놓아야 다른 고객이 구매할 수 있으므로 재고 복구가 필수다.
+     * - @Transactional 로 묶어 전체가 원자적으로 실행된다.
+     */
+    @Transactional
+    public void failPaymentAndOrder(Long orderId) {
+        Payment payment = paymentService.findByOrderIdWithOrder(orderId);
+        Order order = payment.getOrder();
+
+        paymentService.failPayment(payment);
+        orderService.cancelOrder(order);
+
+        restoreStock(order);
+    }
+
+    /**
+     * 결제 승인 처리
+     *
+     * 흐름:
+     *   1) 주문 ID로 결제 + 주문을 함께 조회 (fetch join)
+     *   2) 결제 상태 → PAID
+     *   3) 주문 상태 → CONFIRMED
+     *   4) 화면/클라이언트에 내려줄 응답 DTO 생성
+     *
+     * 승인은 PG사 검증이 끝난 뒤 최종적으로 "결제 완료"를 확정 짓는 단계
+     * 여기서 상태가 바뀌어야 이후 배송/취소 흐름이 이어진다.
+     */
+    @Transactional
+    public PaymentConfirmResponse approvePaymentAndOrder(Long orderId) {
+        Payment payment = paymentService.findByOrderIdWithOrder(orderId);
+        Order order = payment.getOrder();
+
+        paymentService.confirmPayment(payment);
+        orderService.confirmOrder(order);
+
+        return new PaymentConfirmResponse(
+                payment.getId(),
+                orderId,
+                payment.getAmount(),
+                payment.getStatus().name(),
+                order.getStatus().name(),
+                "결제가 완료되었습니다."
+        );
+    }
+
+    /**
+     * 주문에 담긴 상품들의 재고를 복구한다.
+     *
+     * 주문이 생성될 때 상품 재고가 수량만큼 차감되므로,
+     * 결제가 실패해서 주문이 취소되면 차감된 만큼 다시 더해 줘야 한다.
+     * OrderItem은 상품의 "스냅샷"이므로 실제 재고 변경은 Product 엔티티에서 수행한다.
+     */
+    private void restoreStock(Order order) {
+        for (OrderItem item : order.getOrderItems()) {
+            Product product = productService.findProductEntity(item.getProductId());
+            product.restoreStock(item.getQuantity());
+        }
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentService.java
@@ -3,6 +3,8 @@ package com.sparta.paymentsystem.domain.payment.service;
 import com.sparta.paymentsystem.domain.order.entity.Order;
 import com.sparta.paymentsystem.domain.payment.entity.Payment;
 import com.sparta.paymentsystem.domain.payment.repository.PaymentRepository;
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +43,24 @@ public class PaymentService {
                         row -> (Long) row[0],
                         row -> (Long) row[1]
                 ));
+    }
+
+    // 주문 단건 상세 조회 : orderId만으로 조회
+    public Payment findByOrderIdWithOrder(Long orderId) {
+        return paymentRepository.findByOrderIdWithOrder(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    // 결제 상태 변경 (PAID)
+    @Transactional
+    public void confirmPayment(Payment payment) {
+        payment.markAsPaid();
+    }
+
+    // 결제 상태 변경 (FAILED)
+    @Transactional
+    public void failPayment(Payment payment) {
+        payment.markAsFailed();
     }
 
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/product/entity/Product.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/product/entity/Product.java
@@ -53,4 +53,11 @@ public class Product extends BaseTimeEntity {
         this.stock -= quantity;
     }
 
+    public void restoreStock(int quantity) {
+        if (quantity <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_QUANTITY);
+        }
+        this.stock += quantity;
+    }
+
 }


### PR DESCRIPTION
**변경 사항**

- Payment 엔티티에 `markAsPaid()`, `markAsFailed()`, `changeStatus()`상태 전이 메서드 추가
- Order 엔티티에 `markAsConfirmed()`, `markAsCancelled()` , `changeStatus()`상태 전이 메서드 추가
- PaymentRepository에 `findByOrderIdWithOrder()` 쿼리 추가
- PaymentService에 `confirmPayment()`, `failPayment()`, `findByOrderIdWithOrder` 메서드 추가
- OrderService에 `confirmOrder()`, `cancelOrder()` 메서드 추가
- PaymentConfirmRequest / PaymentConfirmResponse DTO
- PaymentCommandService (트랜잭션 분리: `failPaymentAndOrder()`, `restoreStock()`, `approvePaymentAndOrder()`)
- Product 엔티티에 `restoreStock()` 메서드 추가
- PaymentFacade.confirmPayment() (승인 5단계: 결제 조회 → PG조회 → 상태검증 → 금액검증 → DB 반영)
- PaymentController (`POST /api/payments/confirm`)

**테스트**

- [x]  수동 테스트 완료 (Postman / 브라우저)
    - 결제 승인 성공 (금액 일치) → 200 OK + PAID/CONFIRMED 상태
- [x]  기존 기능 영향 없음 확인

**스크린샷**

(Postman 테스트 결과 캡처 첨부)

**관련 Issue**

- Closes #19