### PR TITLE
[Chpater 5] 웹훅 수신 및 결제 상태 동기화

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/repository/PaymentRepository.java
@@ -30,4 +30,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     // Payment 조회 시 연관된 Order를 fetch join 으로 함께 로딩 (N+1 방지)
     @Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.id = :paymentId")
     Optional<Payment> findByIdWithOrder(@Param("paymentId") Long paymentId);
+
+    // Webhook에서 받아온 portonePaymentId 조건으로 Payment 조회 시 연관된 Order를 fetch join 으로 함께 로딩
+    @Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.portonePaymentId = :portonePaymentId")
+    Optional<Payment> findByPortonePaymentId(@Param("portonePaymentId") String portonePaymentId);
 }

--- a/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/paymentsystem/domain/payment/service/PaymentService.java
@@ -75,4 +75,10 @@ public class PaymentService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
     }
 
+    // 웹훅에서 수신한 PortOne 쪽 paymentId, 즉 portonePaymentId 기반으로 Payment 조회
+    public Payment findByPortonePaymentId(String portonePaymentId) {
+        return paymentRepository.findByPortonePaymentId(portonePaymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/config/PortOneProperties.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/config/PortOneProperties.java
@@ -13,4 +13,5 @@ public class PortOneProperties {
     private String apiSecret;
     private String storeId;
     private String channelKey;
+    private String webhookSecret;
 }

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/PortOneWebhookVerifier.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/PortOneWebhookVerifier.java
@@ -1,0 +1,33 @@
+package com.sparta.paymentsystem.infra.portone.webhook;
+
+import com.sparta.paymentsystem.infra.portone.config.PortOneProperties;
+import io.portone.sdk.server.errors.WebhookVerificationException;
+import io.portone.sdk.server.webhook.Webhook;
+import io.portone.sdk.server.webhook.WebhookVerifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * PortOne 공식 Server SDK를 이용한 웹훅 시그니처 검증기
+ *
+ * SDK가 HMAC-SHA256 검증·타임스탬프 검증·역직렬화를 모두 담당하므로,
+ * 성공 시 타입 세이프한 {@link Webhook} 객체를 반환해 핸들러가 instanceof로 분기할 수 있게 한다.
+ */
+@Component
+public class PortOneWebhookVerifier {
+
+    private final WebhookVerifier webhookVerifier;
+
+    public PortOneWebhookVerifier(PortOneProperties properties) {
+        this.webhookVerifier = new WebhookVerifier(properties.getWebhookSecret());
+    }
+
+    /**
+     * 웹훅 메시지를 검증하고 파싱된 {@link Webhook} 객체를 반환한다.
+     *
+     * @throws WebhookVerificationException 시그니처·타임스탬프 검증 실패 시
+     */
+    public Webhook verify(String body, String webhookId, String signature, String timestamp) throws WebhookVerificationException {
+        return webhookVerifier.verify(body, webhookId, signature, timestamp);
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookController.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookController.java
@@ -1,0 +1,43 @@
+package com.sparta.paymentsystem.infra.portone.webhook;
+
+import com.sparta.paymentsystem.global.response.ApiResponse;
+import io.portone.sdk.server.errors.WebhookVerificationException;
+import io.portone.sdk.server.webhook.Webhook;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/webhooks")
+@RequiredArgsConstructor
+@Slf4j
+public class WebhookController {
+
+    private final PortOneWebhookVerifier portOneWebhookVerifier;
+    private final WebhookHandler webhookHandler;
+
+    @PostMapping("/portone")
+    public ResponseEntity<ApiResponse<Void>> handlePortOneWebhook(
+            @RequestHeader("webhook-id") String webhookId,
+            @RequestHeader("webhook-timestamp") String webhookTimestamp,
+            @RequestHeader("webhook-signature") String webhookSignature,
+            @RequestBody String body) {
+
+        log.info("[Webhook] received id={} timestamp={}", webhookId, webhookTimestamp);
+
+        // 1. 시그니처 검증 : 실패 시 200 + 경고 로그 (standard-webhooks 권고)
+        Webhook webhook;
+        try {
+            webhook = portOneWebhookVerifier.verify(body, webhookId, webhookSignature, webhookTimestamp);
+        } catch (WebhookVerificationException e) {
+            log.warn("[Webhook] verification failed id={} reason={}", webhookId, e.getMessage());
+            return ResponseEntity.ok(ApiResponse.ok());
+        }
+
+        // 2. 검증 통과 : 핸들러로 위임
+        webhookHandler.handle(webhookId, webhook, body);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookEvent.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookEvent.java
@@ -1,0 +1,64 @@
+package com.sparta.paymentsystem.infra.portone.webhook;
+
+import com.sparta.paymentsystem.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "webhook_events")
+@Getter
+@NoArgsConstructor
+public class WebhookEvent extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "webhook_id", nullable = false, unique = true, length = 200)
+    private String webhookId;
+
+    @Column(nullable = false, length = 100)
+    private String type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private WebhookStatus status;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
+
+    @Column(name = "failure_reason", length = 500)
+    private String failureReason;
+
+    public WebhookEvent(String webhookId, String type, String payload) {
+        this.webhookId = webhookId;
+        this.type = type;
+        this.status = WebhookStatus.RECEIVED;
+        this.payload = payload;
+    }
+
+    public void markAsProcessed() {
+        this.status = WebhookStatus.PROCESSED;
+        this.finishedAt = LocalDateTime.now();
+        this.failureReason = null;
+    }
+
+    public void markAsIgnored(String reason) {
+        this.status = WebhookStatus.IGNORED;
+        this.finishedAt = LocalDateTime.now();
+        this.failureReason = reason;
+    }
+
+    public void markAsFailed(String reason) {
+        this.status = WebhookStatus.FAILED;
+        this.finishedAt = LocalDateTime.now();
+        this.failureReason = reason;
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookEventRepository.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookEventRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.paymentsystem.infra.portone.webhook;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WebhookEventRepository extends JpaRepository<WebhookEvent, Long> {
+    // 동일한 webhookId로 이미 처리된 웹훅이 있는지 확인 (멱등성 보장용)
+    // PortOne이 네트워크 타임아웃 등으로 같은 이벤트를 재전송해도 중복 처리되지 않도록 사전 체크한다.
+    // 실제 쿼리: SELECT we.id FROM webhook_events we WHERE we.webhook_id = ? LIMIT 1;
+    boolean existsByWebhookId(String webhookId);
+
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookEventService.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookEventService.java
@@ -1,0 +1,61 @@
+package com.sparta.paymentsystem.infra.portone.webhook;
+
+import com.sparta.paymentsystem.global.error.BusinessException;
+import com.sparta.paymentsystem.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 웹훅 이벤트의 수신/처리 이력을 관리하는 서비스
+ *
+ * PortOne 웹훅은 네트워크 사정에 따라 같은 이벤트가 여러 번 도착할 수 있으므로(재전송),
+ * "이미 본 이벤트인지" 판별하고 처리 결과(PROCESSED/IGNORED/FAILED)를 DB에 기록하는 역할을 한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WebhookEventService {
+
+    private final WebhookEventRepository webhookEventRepository;
+
+    // 중복이 아니면 RECEIVED 상태로 저장하고, 중복이면 Optional.empty()를 돌려준다.
+    // 호출부는 Optional.empty()를 받으면 "이미 처리된 웹훅이니 무시"로 해석해 200 OK만 응답하면 된다.
+    //
+    // 실제 쿼리 (두 단계로 나가며, 중복이면 1번 쿼리만 실행된다):
+    //   1) 중복 체크: SELECT we.id FROM webhook_events we WHERE we.webhook_id = ? LIMIT 1;
+    //   2) 신규 저장: INSERT INTO webhook_events
+    //                (created_at, failure_reason, finished_at, payload, status, type, updated_at, webhook_id)
+    //                values (?, ?, ?, ?, 'RECEIVED', ?, ?, ?);
+    public Optional<WebhookEvent> saveIfNotDuplicate(String webhookId, String type, String payload) {
+        if (webhookEventRepository.existsByWebhookId(webhookId)) {
+            return Optional.empty();
+        }
+        return Optional.of(webhookEventRepository.save(new WebhookEvent(webhookId, type, payload)));
+    }
+
+    // 웹훅 본 처리 로직이 성공한 경우 호출. status를 PROCESSED로, finished_at을 now()로 바꾼다.
+    public void markProcessed(Long eventId) {
+        load(eventId).markAsProcessed();
+    }
+
+    // "처리할 필요 없는 이벤트"(예: 우리가 모르는 type, 이미 취소된 결제 등)일 때 호출
+    // 실패가 아니라 "의도적으로 건너뜀"을 구분하기 위해 별도 상태(IGNORED)로 남긴다.
+    public void markIgnored(Long eventId, String reason) {
+        load(eventId).markAsIgnored(reason);
+    }
+
+    // 본 처리 중 예외가 난 경우 호출. 재처리/모니터링을 위해 실패 사유를 남긴다.
+    public void markFailed(Long eventId, String reason) {
+        load(eventId).markAsFailed(reason);
+    }
+
+    // PK로 조회하되, 없으면 비즈니스 예외로 변환한다.
+    private WebhookEvent load(Long eventId) {
+        return webhookEventRepository.findById(eventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WEBHOOK_EVENT_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookHandler.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookHandler.java
@@ -1,0 +1,169 @@
+package com.sparta.paymentsystem.infra.portone.webhook;
+
+import com.sparta.paymentsystem.domain.payment.entity.Payment;
+import com.sparta.paymentsystem.domain.payment.entity.PaymentStatus;
+import com.sparta.paymentsystem.domain.payment.port.PaymentGateway;
+import com.sparta.paymentsystem.domain.payment.port.PaymentGatewayResponse;
+import com.sparta.paymentsystem.domain.payment.service.PaymentCommandService;
+import com.sparta.paymentsystem.domain.payment.service.PaymentService;
+import io.portone.sdk.server.webhook.Webhook;
+import io.portone.sdk.server.webhook.WebhookTransactionCancelledCancelled;
+import io.portone.sdk.server.webhook.WebhookTransactionPaid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * PortOne 웹훅 처리 핸들러
+ *
+ * [설계 원칙]
+ *
+ * 1. 외부 API 호출(PG 조회)은 트랜잭션 밖에서 실행한다.
+ *    -> 커넥션 풀 오래 점유 방지 + 외부 응답 지연이 DB에 영향을 주지 않도록
+ *    실제 DB 변경은 PaymentCommandService의 @Transactional 메서드 안에서 일어난다.
+ *
+ * 2. PG사(PortOne)가 보내주는 이벤트 페이로드를 그대로 믿지 않는다.
+ *    반드시 PG에 다시 조회(getPayment)해서 실체 상태와 금액을 재확인한다.
+ *    -> 웹훅 위조 가능성, 페이로드 변조 가능성을 방어하는 보안 원칙
+ *
+ * 3. Client 결제 확정(PaymentFacade.confirmPayment)과 중복 처리되지 않도록
+ *    payment.status를 확인해 이미 처리된 건은 상태 변경을 생략한다.
+ *    -> 같은 결제에 대해 승인/취소가 두 번 일어나는 것을 원천 차단.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebhookHandler {
+
+    private final PaymentService paymentService;
+    private final PaymentCommandService paymentCommandService;
+    private final PaymentGateway paymentGateway;
+    private final WebhookEventService webhookEventService;
+
+    /**
+     * 웹훅 진입점
+     *
+     * 흐름:
+     *   1. 멱등성 체크 (webhook_id 중복 여부)
+     *   2. 이벤트 DB 저장 (RECEIVED 상태로)
+     *   3. 타입별 처리 분기
+     *   4. 실패 시 FAILED 마킹
+     */
+    public void handle(String webhookId, Webhook webhook, String rawPayload) {
+
+        // 수신한 웹훅의 "종류"를 문자열로 뽑아낸다. 예) "WebhookTransactionPaid", "WebhookTransactionCancelledCancelled"
+        // PortOne SDK는 이벤트를 sealed class 계층(Webhook 하위 타입들)으로 돌려주기 때문에
+        // "무슨 타입의 이벤트인지"를 런타임 클래스명으로 식별할 수 있다.
+        //
+        // 이 type 값은 두 곳에서 쓰인다:
+        //   1) webhook_events 테이블의 type 컬럼으로 저장 -> 나중에 운영자가 "어떤 이벤트였는지" 조회/통계 낼 때 사용
+        //      (실제 쿼리의 INSERT ... VALUES (?, ?, ...) 두 번째 ? 자리에 들어간다)
+        //   2) 아래 instanceof 분기에서 처리 대상이 아닌 경우, markIgnored 사유 메시지로 기록
+        //      (예: "처리 대상 아님: WebhookTransactionReady")
+        String type = webhook.getClass().getSimpleName();
+
+        // 1. 멱등성: 같은 webhook_id가 이미 저장돼 있으면 중복 이벤트 -> 스킵
+        //    PG가 네트워크 이슈로 같은 이벤트를 여러 번 보내도 한 번만 처리된다.
+        Optional<WebhookEvent> saved = webhookEventService.saveIfNotDuplicate(webhookId, type, rawPayload);
+        if (saved.isEmpty()) return;
+        Long eventId = saved.get().getId();
+
+        // 2. 타입별 처리. 어떤 예외가 터져도 WebhookEvent는 FAILED로 기록되어야
+        //    나중에 운영자가 실패 건을 추적·재처리할 수 있다.
+        try {
+            if (webhook instanceof WebhookTransactionPaid p) {
+                handlePaid(eventId, p.getData().getPaymentId());
+            } else if (webhook instanceof WebhookTransactionCancelledCancelled c) {
+                handleCancel(eventId, c.getData().getPaymentId());
+            } else {
+                // 우리가 처리 대상으로 삼지 않는 이벤트 타입 (예: Transaction.Ready)
+                // -> 무시하되, 이벤트는 받았다는 기록을 남긴다.
+                webhookEventService.markIgnored(eventId, "처리 대상 아님: " + type);
+            }
+        } catch (Exception e) {
+            log.error("[Webhook] failed eventId={}", eventId, e);
+            webhookEventService.markFailed(eventId, e.getMessage());
+        }
+    }
+
+    /**
+     * 결제 완료(Transaction.Paid) 웹훅 처리
+     *
+     * 이 웹훅이 오는 시나리오:
+     *  - Client가 confirmPayment를 호출하기 전에 PG가 먼저 웹훅을 보낸 경우
+     *  - Client가 confirmPayment 응답을 못 받고 화면을 닫은 경우(네트워크 끊김)
+     *  - 이미 Client에서 승인 처리가 끝난 뒤 도착한 보조 확인용 웹훅
+     */
+    private void handlePaid(Long eventId, String portonePaymentId) {
+        // [보안] PG 페이로드는 신뢰하지 않고 실체를 직접 조회한다.
+        //        외부 API 호출이므로 트랜잭션 밖에서 실행된다.
+        PaymentGatewayResponse pg = paymentGateway.getPayment(portonePaymentId);
+
+        // PG 실체 상태가 PAID가 아니면 처리 대상이 아님
+        // (예: 웹훅은 Paid로 왔는데 실체는 이미 CANCELLED로 바뀐 경우)
+        if (!"PAID".equals(pg.status())) {
+            webhookEventService.markIgnored(eventId, "PG 상태가 PAID가 아님: " + pg.status());
+            return;
+        }
+
+        Payment payment = paymentService.findByPortonePaymentId(portonePaymentId);
+
+        // [보안] 금액 조작 방어
+        // 우리가 생성한 결제 금액(DB)과 PG가 실제로 승인한 금액이 다르면
+        // 프론트엔드가 조작되었거나 외부 공격이 있었다는 뜻 -> FAILED로 기록
+        if (pg.totalAmount() != payment.getAmount()) {
+            webhookEventService.markFailed(eventId, "금액 불일치: db=" + payment.getAmount() + ", pg=" + pg.totalAmount());
+            return;
+        }
+
+        // [중복 처리 방지]
+        // Client의 confirmPayment가 먼저 성공했다면 payment는 이미 PAID 상태다.
+        // 이 경우 approvePaymentAndOrder를 다시 호출하면 상태 머신이 예외를 던진다.
+        // IN_PROGRESS일 때만 실제 상태 변경을 수행하고, 이미 PAID면 스킵한다.
+        // -> Client 경로와 웹훅 경로가 서로 다른 시점에 도착해도 결과는 한 번만 반영된다.
+        if (payment.getStatus() == PaymentStatus.IN_PROGRESS) {
+            paymentCommandService.approvePaymentAndOrder(payment.getOrder().getId());
+        }
+
+        // 상태 변경을 수행했든 스킵했든 "이 이벤트는 처리 완료"로 기록한다.
+        // PG가 같은 이벤트를 재전송하지 않도록 200 응답의 근거가 된다.
+        webhookEventService.markProcessed(eventId);
+    }
+
+    /**
+     * 결제 취소(Transaction.Cancelled) 웹훅 처리
+     *
+     * 이 웹훅이 오는 시나리오:
+     *  - 우리가 /payments/{id}/cancel을 호출한 뒤 PG가 확인용으로 보낸 웹훅
+     *  - PG 관리자 콘솔에서 수동 취소한 경우
+     *  - 카드사 측에서 취소가 역행된 경우
+     *
+     * handlePaid와 대칭 구조다. 다른 점은 금액 검증이 없다는 것
+     * 취소는 금액이 변하는 행위가 아니므로 확인이 불필요하다.
+     */
+    private void handleCancel(Long eventId, String portonePaymentId) {
+        // [보안] PG 실체를 직접 조회 (외부 API, 트랜잭션 밖)
+        PaymentGatewayResponse pg = paymentGateway.getPayment(portonePaymentId);
+
+        // PG 실체가 CANCELLED가 아니면 처리 대상이 아님
+        if (!"CANCELLED".equals(pg.status())) {
+            webhookEventService.markIgnored(eventId, "PG 상태가 CANCELLED가 아님: " + pg.status());
+            return;
+        }
+
+        Payment payment = paymentService.findByPortonePaymentId(portonePaymentId);
+
+        // [중복 처리 방지]
+        // Client의 cancelPayment가 먼저 성공했다면 payment는 이미 CANCELLED 상태다.
+        // PAID일 때만 실제 취소 로직을 수행한다.
+        // -> Client 취소와 웹훅 취소가 모두 도착해도 실제 취소는 한 번만 일어난다.
+        if (payment.getStatus() == PaymentStatus.PAID) {
+            paymentCommandService.cancelPaymentAndOrder(payment.getId(), "PG사 상태 동기화에 의한 취소");
+        }
+
+        webhookEventService.markProcessed(eventId);
+    }
+
+}

--- a/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookStatus.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/webhook/WebhookStatus.java
@@ -1,0 +1,15 @@
+package com.sparta.paymentsystem.infra.portone.webhook;
+
+/**
+ * 웹훅 이벤트 처리 상태
+ * - RECEIVED:  수신 완료, 처리 전
+ * - PROCESSED: 정상 처리 완료
+ * - IGNORED:   알고는 있으나 처리 대상이 아닌 이벤트 (예: Transaction.Ready)
+ * - FAILED:    처리 중 에러 발생 → 재처리 대상
+ */
+public enum WebhookStatus {
+    RECEIVED,
+    PROCESSED,
+    IGNORED,
+    FAILED
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,3 +41,4 @@ portone:
   api-secret: ${PORTONE_API_SECRET}
   store-id: ${PORTONE_STORE_ID}
   channel-key: ${PORTONE_CHANNEL_KEY}
+  webhook-secret: ${PORTONE_WEBHOOK_SECRET}


### PR DESCRIPTION
### 변경 사항

- WebhookEvent 엔티티 및 Repository & Status 구현
- WebhookEventService 구현
- PaymentService & PaymentRepository 구현
- WebhookHandler 구현
- PortOne SDK를 활용한 HMAC-SHA256 서명 검증 로직 구현
- POST /api/webhooks/portone 엔드포인트 추가
- [smee.io](http://smee.io/) 연동 가이드 및 application.yml 설정 추가

### 테스트

- [x]  수동 테스트 완료 ([smee.io](http://smee.io/))
    - [smee.io](http://smee.io/)를 통해 웹훅 수신 → 200 OK 확인
- [x]  기존 기능 영향 없음 확인

### 스크린샷

([smee.io](http://smee.io/) 대시보드 및 웹훅 수신 로그 캡처)

### 관련 Issue

- Closes #23