### PR TITLE
[Chpater 5] 멱등성 키를 활용한 결제 취소 재시도

### DIFF
--- a/src/main/java/com/sparta/paymentsystem/infra/portone/client/PortOneClient.java
+++ b/src/main/java/com/sparta/paymentsystem/infra/portone/client/PortOneClient.java
@@ -8,7 +8,10 @@ import com.sparta.paymentsystem.infra.portone.dto.PortOnePaymentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
+
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -40,16 +43,35 @@ public class PortOneClient implements PaymentGateway {
         );
     }
 
+    /**
+     * 결제 전액 취소
+     * 교육용, 개념 설명을 위한 코드
+     *
+     * Idempotency-Key가 있으면 PortOne이
+     * "아, 아까 그 요청이구나" 하고 이전 성공 응답을 그대로 반환해준다.
+     */
     @Override
     public void cancelPayment(String paymentId, String reason) {
-        // paymentId logging
-        log.info("PortOne 결제 취소 요청: paymentId={}, reason={}", paymentId, reason);
+        String idempotencyKey = UUID.randomUUID().toString();
+        log.info("PortOne 결제 취소 요청: paymentId={}, reason={}, idempotencyKey={}", paymentId, reason, idempotencyKey);
 
-        // portOneRestClient https://api.portone.io/payments/{paymnetId}/cancel body: {reason, storeId}
-        portOneRestClient.post()
-                .uri("/payments/{paymentId}/cancel", paymentId)
-                .body(new PortOneCancelRequest(reason, portOneProperties.getStoreId()))
-                .retrieve()
-                .toBodilessEntity();
+        int maxRetries = 3;
+
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                // portOneRestClient https://api.portone.io/payments/{paymnetId}/cancel body: {reason, storeId}
+                portOneRestClient.post()
+                        .uri("/payments/{paymentId}/cancel", paymentId)
+                        .header("Idempotency-Key", "\"" + idempotencyKey + "\"") // 같은 키 유지
+                        .body(new PortOneCancelRequest(reason, portOneProperties.getStoreId()))
+                        .retrieve()
+                        .toBodilessEntity();
+                return;  // 성공하면 종료
+            } catch (ResourceAccessException e) {
+                // 네트워크 타임아웃 -> 재시도
+                log.warn("PortOne 취소 요청 타임아웃 (시도 {}/{})", attempt, maxRetries);
+                if (attempt == maxRetries) throw e;
+            }
+        }
     }
 }


### PR DESCRIPTION
### 변경 사항

- cancelPayment 호출 시 Idempotency-Key 헤더 추가 (UUID)
- ResourceAccessException 발생 시 재시도 로직 구현 (최대 3회)
- 동일 Idempotency-Key로 중복 취소 요청 시 멱등성 보장

### 테스트

- [x]  수동 테스트 완료 (Postman)
    - 정상 취소 요청 → 200 OK, Idempotency-Key 헤더 확인
- [x]  기존 기능 영향 없음 확인

### 스크린샷

(Postman 요청 헤더에 Idempotency-Key 포함된 캡처)

### 관련 Issue

- Closes #25
